### PR TITLE
Update documentation links

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -39,7 +39,7 @@ About						</li>
 						<li class="menu-title">
 Technology						</li>
 						<li><a href="https://z.cash/download.html">Download Zcash</a></li>
-						<li><a href="https://zcash.readthedocs.io/en/latest/rtd_pages/rtd_docs/user_guide.html">1.0 User Guide</a></li>
+						<li><a href="https://zcash.readthedocs.io/en/latest/rtd_pages/rtd_docs/user_guide.html">User Guide</a></li>
 						<li><a href="https://github.com/zcash/zcash">GitHub</a></li>
 						<li><a href="https://github.com/zcash/zcash/issues">Report a bug</a></li>
 						<li><a href="https://z.cash/technology/paramgen.html">Paramgen</a></li>

--- a/footer.php
+++ b/footer.php
@@ -18,7 +18,7 @@
 
 		<footer id="colophon" class="site-footer" role="contentinfo">
 			<div class="wrap">
-				
+
 		<div class="footer-menu">
 			<div class="menu-items grid-flex-container">
 				<div class="grid-flex-cell">
@@ -39,7 +39,7 @@ About						</li>
 						<li class="menu-title">
 Technology						</li>
 						<li><a href="https://z.cash/download.html">Download Zcash</a></li>
-						<li><a href="https://zcash.readthedocs.io/en/latest/rtd_pages/rtd_docs/payment_api.html">1.0 User Guide</a></li>
+						<li><a href="https://zcash.readthedocs.io/en/latest/rtd_pages/rtd_docs/user_guide.html">1.0 User Guide</a></li>
 						<li><a href="https://github.com/zcash/zcash">GitHub</a></li>
 						<li><a href="https://github.com/zcash/zcash/issues">Report a bug</a></li>
 						<li><a href="https://z.cash/technology/paramgen.html">Paramgen</a></li>
@@ -133,8 +133,8 @@ Community						</li>
 				</div>
 			</div>
 			<p><span class="copy">© 2017 Zerocoin Electric Coin Company</span></p>
-		</div>				
-				
+		</div>
+
 			</div><!-- .wrap -->
 		</footer><!-- #colophon -->
 	</div><!-- .site-content-contain -->

--- a/footer.php
+++ b/footer.php
@@ -39,7 +39,7 @@ About						</li>
 						<li class="menu-title">
 Technology						</li>
 						<li><a href="https://z.cash/download.html">Download Zcash</a></li>
-						<li><a href="https://github.com/zcash/zcash/wiki/1.0-User-Guide">1.0 User Guide</a></li>
+						<li><a href="https://zcash.readthedocs.io/en/latest/rtd_pages/rtd_docs/payment_api.html">1.0 User Guide</a></li>
 						<li><a href="https://github.com/zcash/zcash">GitHub</a></li>
 						<li><a href="https://github.com/zcash/zcash/issues">Report a bug</a></li>
 						<li><a href="https://z.cash/technology/paramgen.html">Paramgen</a></li>

--- a/single.php
+++ b/single.php
@@ -28,8 +28,8 @@ get_header(); ?>
 				endif;
 
 				the_post_navigation( array(
-					'prev_text' => '<span class="screen-reader-text">' . __( 'Previous Post', 'twentyseventeen' ) . '</span><span aria-hidden="true" class="nav-subtitle">' . __( 'Previous', 'twentyseventeen' ) . '</span> <span class="nav-title"><span class="nav-title-icon-wrapper">' . twentyseventeen_get_svg( array( 'icon' => 'arrow-left' ) ) . '</span>%title</span>',
-					'next_text' => '<span class="screen-reader-text">' . __( 'Next Post', 'twentyseventeen' ) . '</span><span aria-hidden="true" class="nav-subtitle">' . __( 'Next', 'twentyseventeen' ) . '</span> <span class="nav-title">%title<span class="nav-title-icon-wrapper">' . twentyseventeen_get_svg( array( 'icon' => 'arrow-right' ) ) . '</span></span>',
+					'prev_text' => '<span class="screen-reader-text">' . __( 'Previous Post', 'twentyseventeen' ) . '</span><span aria-hidden="true" class="nav-subtitle">' . __( 'Previous', 'twentyseventeen' ) . '</span> <span class="nav-title"><span class="nav-title-icon-wrapper">' . twentyseventeen_get_svg( array( 'icon' => 'arrow-left' ) ) . '</span><span class="nav-title-text">%title</span></span>',
+					'next_text' => '<span class="screen-reader-text">' . __( 'Next Post', 'twentyseventeen' ) . '</span><span aria-hidden="true" class="nav-subtitle">' . __( 'Next', 'twentyseventeen' ) . '</span> <span class="nav-title"><span class="nav-title-text">%title</span><span class="nav-title-icon-wrapper">' . twentyseventeen_get_svg( array( 'icon' => 'arrow-right' ) ) . '</span></span>',
 				) );
 
 			endwhile; // End of the loop.


### PR DESCRIPTION
Changes links for User Guide from github to readthedocs
Also adds a wrapper on next/prev post title for the sake of translations which I forgot to commit earlier.